### PR TITLE
feat: Add CustomPrompt and CustomImage params to script

### DIFF
--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -848,7 +848,12 @@ function SetCustomImage {
 	}
 	
 	if (Test-Path $CustomImage) {
-		Set-ItemProperty 'HKLM:\software\EvoSecurity\EvoLogin-CP' 'v1_bitmap_path' $CustomImage
+	if (-not (Test-Path 'HKLM:\software\EvoSecurity\EvoLogin-CP')) {
+		Write-Error "Registry key 'HKLM:\software\EvoSecurity\EvoLogin-CP' does not exist. Ensure the agent is properly installed."
+		return
+	}
+	
+	Set-ItemProperty 'HKLM:\software\EvoSecurity\EvoLogin-CP' 'v1_bitmap_path' $CustomImage
 	} else {
 		$GoodUri = [uri]::IsWellFormedUriString($CustomImage, 'Absolute') -and ([uri] $CustomImage).Scheme -in 'http', 'https'
 		if (-not $GoodUri) {

--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -830,6 +830,11 @@ function SetCustomPrompt {
 		return
 	}
 	
+	if (-not (Test-Path 'HKLM:\software\EvoSecurity\EvoLogin-CP')) {
+		Write-Error "Registry key 'HKLM:\software\EvoSecurity\EvoLogin-CP' does not exist. Ensure the agent is properly installed."
+		return
+	}
+	
 	Set-ItemProperty 'HKLM:\software\EvoSecurity\EvoLogin-CP' 'login_text' $CustomPrompt
 }
 

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,8 @@ This repository contains a PowerShell script to install, upgrade, or remove the 
 | `-JitMode`                | Optional flag to enable Just-In-Time admin accounts           | 0                                           |
 | `-EndUserElevation`       | Optional flag to enable end-user elevation                    | 0                                           |
 | `-UserAdminEscalation`    | Optional flag to prompt admins with the end-user elevation prompt instead of the standard UAC prompt | 0    |
+| `-CustomPrompt`           | Optional string to customize the login prompt                 |                                             |
+| `-CustomImage`            | Optional path to custom login image (URL or local file path   |                                             |
 | `-NoElevatedRDP`          | Optional flag to disable elevation for RDP sessions when Evo is the sole login agent | 1                    |
 | `-MSIPath`                | Optional path to `.msi` or `.zip` file                        |                                             |
 | `-Upgrade`                | Ensure only newer versions replace installed ones             |                                             |


### PR DESCRIPTION
Added two parameters to the script (and the JSON payload)

-CustomPrompt
-CustomImage

CustomPrompt changes from "Evo Secure Login" in the CredPro display to the value the customer sets

CustomImage changes from the default Evo logo to a custom customer image

Testing:
Ran the script both via total command line parameters and also using the JSON payload. Both work. Tried using a local file and an image on my personal website. Both ways work.

