### PR TITLE
AG-399 Add -UACExtension option to installer

### DIFF
--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -56,6 +56,9 @@
 .PARAMETER NoElevatedRDP
     Optional flag to disable elevation for RDP sessions when Evo is the sole login agent
 
+.PARAMETER UACExtension
+    Optional setting to enable UAC extension (0=disabled, 1=enabled, other credential providers available in UAC dialog, 2=enabled, Evo exclusive in UAC dialog )
+
 .PARAMETER MSIPath
     Optional path to a .msi or .zip file. If omitted, the latest version is downloaded.
 
@@ -131,6 +134,9 @@ param(
 
     [Parameter(ParameterSetName='CommandLineConfig')]
     [Nullable[int]] [ValidateSet(0, 1)] $RememberLastUserName,
+
+    [Parameter(ParameterSetName='CommandLineConfig')]
+    [Nullable[int]] [ValidateSet(0, 1, 2)] $UACExtension,
 
     [Parameter(ParameterSetName='CommandLineConfig', HelpMessage='Leave blank to download latest. Otherwise path to MSI or zip file to install')]
     [string] $MSIPath,
@@ -212,6 +218,7 @@ Parameters:
   -CustomPrompt           Optional path to a custom login prompt label
   -CustomImage            Optional path to a custom login prompt image
   -NoElevatedRDP          Optional flag to disable elevation for RDP sessions when Evo is the sole login agent (defaults on or value of previous install)
+  -UACExtension           Optional setting to enable UAC extension (0=disabled, 1=enabled, other credential providers available in UAC dialog, 2=enabled, Evo exclusive in UAC dialog ) (defaults disabled or value of previous install)
   -MSIPath                Optional .msi or .zip file path
   -Upgrade                Validate version is newer before installing
   -Remove                 Uninstall agent
@@ -581,6 +588,16 @@ function ParamMapFromJson {
     }
     elseif ($config.RememberLastUserName -eq 0) {
         $ParamMap["ENABLE_LAST_USERNAME"] = 0
+    }
+
+    if ($config.UACExtension -eq 0) {
+        $ParamMap["UAC_EXTENSION"] = 0
+    }
+    elseif ($config.UACExtension -eq 1) {
+        $ParamMap["UAC_EXTENSION"] = 1
+    }
+    elseif ($config.UACExtension -eq 2) {
+        $ParamMap["UAC_EXTENSION"] = 2
     }
 
     # trim string values in ParamMap
@@ -967,6 +984,9 @@ if (-not $Json) {
     }
     if ($null -ne $RememberLastUserName) {
         $MapForJson += @{ RememberLastUserName = $RememberLastUserName}
+    }
+    if ($null -ne $UACExtension) {
+        $MapForJson += @{ UACExtension = $UACExtension}
     }
     if ($MSIPath) {
         $MapForJson += @{ MSIPath = $MSIPath}

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ This repository contains a PowerShell script to install, upgrade, or remove the 
 | `-CustomPrompt`           | Optional string to customize the login prompt                 |                                             |
 | `-CustomImage`            | Optional path to custom login image (URL or local file path   |                                             |
 | `-NoElevatedRDP`          | Optional flag to disable elevation for RDP sessions when Evo is the sole login agent | 1                    |
+| `-UACExtension`           | Optional setting to enable UAC extension (0=disabled, 1=enabled, other credential providers available in UAC dialog, 2=enabled, Evo exclusive in UAC dialog )                      | 0                                           |
 | `-MSIPath`                | Optional path to `.msi` or `.zip` file                        |                                             |
 | `-Upgrade`                | Ensure only newer versions replace installed ones             |                                             |
 | `-Remove`                 | Uninstalls the Evo Credential Provider                        |                                             |


### PR DESCRIPTION
Added -UACExtension option to installer. Here are screenshots for testing with the values set with a script call like: 

Missing or 0:
<img width="495" height="475" alt="image" src="https://github.com/user-attachments/assets/be0d3152-d511-4856-8eb5-88992ec8b23d" />

1:
<img width="495" height="475" alt="image" src="https://github.com/user-attachments/assets/27a35a7b-3341-4366-838d-fbfa16daac05" />

2:
<img width="495" height="475" alt="image" src="https://github.com/user-attachments/assets/fac1cf47-598d-4c67-bf88-1268c7c2ee9a" />


