### PR TITLE
Change OnlyEvoLoginCredential type to Nullable[int]

### DIFF
--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -112,7 +112,7 @@ param(
     [string] $CredentialMode,
 
     [Parameter(ParameterSetName='CommandLineConfig')]
-    [Nullable[bool]] $OnlyEvoLoginCredential,
+    [Nullable[int]] [ValidateSet(0, 1)] $OnlyEvoLoginCredential,
 
     [Parameter(ParameterSetName='CommandLineConfig')]
     [switch] $NoElevatedRDP,


### PR DESCRIPTION
Allows variable to be both an int or string when being passed to the script.