### PR TITLE
Added Ninja Fields integration

### DIFF
--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -215,6 +215,24 @@ param(
     [switch] $Help
 )
 
+if (-not $DeploymentToken) {
+    try {
+        Write-Host "Retrieving Deployment Token using Ninja-Property-Get..."
+        $DeploymentToken = (Ninja-Property-Get evoDeploymentToken | Out-String).Trim()
+ 
+        if (-not $DeploymentToken) {
+            throw "Ninja-Property-Get returned no value for evoDeploymentToken."
+        }
+
+        Write-Host "Retrieved Deployment Token successfully."
+    }
+    catch {
+        Write-Error "Failed to retrieve Deployment Token using Ninja-Property-Get: $_"
+        exit 1
+    }
+}
+
+
 function Show-Help {
     @"
 Evo Windows Agent Installer


### PR DESCRIPTION
Hello Evo,

We wanted to use the installer with Ninja and wanted to make the process a little simpler. Here's some code that enables us to use a Ninja secure/password field to retrieve the deployment token so we don't need to set specific command line switches for every client. I just figured we'd share what we did to make this work in case your other clients want to do the same thing. 

This only works if the evoDeploymentToken field is already created in Ninja.