### PR TITLE
AG-604 Add -RMM argument for Ninja deployment token retrieval

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Minimum supported Agent version for any option is 2.3 unless indicated otherwise
 | `-DisableEvoUac`          | Optional setting to disable the Evo credential in the UAC dialog (Minimum supported agent = 2.4)                                                              | 0                      |
 | `-UnlimitedExtendedUacSession`  | Optional setting to enable unlimited extended UAC session  (Minimum supported agent = 2.4)                                                              | 0                      |
 | `-PersistentRequest`      | Optional setting to enable persistent elevation request notifications instead of having a 10 second timeout (Minimum supported agent = 2.4)                   | 0                      |
+| `-RMM`                    | Optional setting to enable RMM (Remote Monitoring and Management) functionality. Only Ninja deployment token retrieval for now (Minimum supported agent = 2.5)|                        |
 | `-MSIPath`                | Optional path to `.msi` or `.zip` file                                                                                                                        |                        |
 | `-Upgrade`                | Ensure only newer versions replace installed ones                                                                                                             |                        |
 | `-Remove`                 | Uninstalls the Evo Credential Provider                                                                                                                        |                        |
@@ -87,6 +88,14 @@ When upgrading, any unspecified parameters are inherited from the previous insta
 ```powershell
 .\InstallEvoAgent.ps1 -DeploymentToken "deptoken123abc"
 ```
+
+### Install with Ninja deployment token retrieval (agent 2.5+)
+
+In this case, `evoDeploymentToken` is the property you've defined to hold the deployment token in your Ninja configuration
+```powershell
+.\InstallEvoAgent.ps1 -DeploymentToken evoDeploymentToken -RMM Ninja
+```
+
 
 ### Basic Install (still supported)
 


### PR DESCRIPTION
Add -RMM argument for Ninja deployment token retrieval
The only supported RMM now is Ninja
If `-RMM Ninja` is specified, then `-DeploymentToken` is treated as a property to be fetched from Ninja

Fake `Ninja-Property-Get.ps1` in my path
```
[CmdletBinding()]
param (
    [string] $value
)

if ($value -eq 'evoDeploymentToken') {
    return "axkxxkk"
}

return $null
```

Testing:
Used above fake Ninja-Property-Get sometimes.

1. No -RMM, just used deployment token
2. `-RMM Ninja` but no token, error message: `An RMM was specified (Ninja) but the required token property was not provided`
3. `-RMM xyz  -DeploymentToken xxx`, error message `RMM xyz is not currently supported by this script.`
4. `-RMM Ninja -DeploymentToken xxx`, error message `Failed to retrieve from Ninja: Property is empty.`
5. `-RMM Ninja -DeploymentToken evoDeploymentToken`, did install

If I renamed the script to something else:
 `Failed to retrieve from Ninja: Ninja-Property-Get command not found. Is the Ninja Agent installed?`

