### PR TITLE
[AG-683] Fix InstallEvoAgent.ps1 null error after hybrid agent install

### DIFF
--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -980,6 +980,20 @@ function GetServiceLocation {
     return ($Item.ImagePath).Trim('"') # can be wrapped in quotes which we want to remove
 }
 
+function GetAgentLocation {
+    $ServiceNames = @('EvoAgent', 'EvoSecureLoginAgent')
+
+    foreach ($ServiceName in $ServiceNames) {
+        $ServiceLocation = GetServiceLocation $ServiceName
+        if ($ServiceLocation) {
+            Write-Verbose "Found agent service location using service name: $ServiceName"
+            return $ServiceLocation
+        }
+    }
+
+    return $null
+}
+
 function SetCustomPrompt {
     param (
         [string]$CustomPrompt
@@ -1260,7 +1274,7 @@ try {
     SetCustomPrompt $JsonMap.CustomPrompt
 
     if ($JsonMap.CustomImage) {
-        $AgentLocation = GetServiceLocation 'EvoSecureLoginAgent'
+		$AgentLocation = GetAgentLocation
         Write-Verbose "AgentLocation: $AgentLocation"
         if ($AgentLocation -and (Test-Path $AgentLocation)) {
             $AgentDirectory = (Get-Item $AgentLocation).DirectoryName

--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -973,7 +973,11 @@ function GetServiceLocation {
 	)
 	
 	$Item = Get-ItemProperty "hklm:\System\CurrentControlSet\Services\$ServiceName" 'ImagePath' -ErrorAction Ignore
-	return ($Item.ImagePath).Trim('"') # can be wrapped in quotes which we want to remove
+    if (-not $Item -or -not $Item.ImagePath) {
+        return $null
+    }
+
+    return ($Item.ImagePath).Trim('"') # can be wrapped in quotes which we want to remove
 }
 
 function SetCustomPrompt {
@@ -1251,18 +1255,20 @@ try {
         LogFileName = if ($Log) { GetLogFileName $ProductType $true } else { "" }
     }
     InstallMSI @InstallMSIArgs
-	
-	$AgentLocation = GetServiceLocation 'EvoSecureLoginAgent'
-	Write-Verbose "AgentLocation: $AgentLocation"
-	if (Test-Path $AgentLocation) {
-		$AgentDirectory = (Get-Item $AgentLocation).DirectoryName
-		$JsonMap = ConvertFrom-Json (GetJsonRawContent $json)
-		
-		SetCustomPrompt $JsonMap.CustomPrompt
-		SetCustomImage $JsonMap.CustomImage $AgentDirectory
-	} else {
-		Write-Error "Could not find agent location"
-	}
+
+    $JsonMap = ConvertFrom-Json (GetJsonRawContent $json)
+    SetCustomPrompt $JsonMap.CustomPrompt
+
+    if ($JsonMap.CustomImage) {
+        $AgentLocation = GetServiceLocation 'EvoSecureLoginAgent'
+        Write-Verbose "AgentLocation: $AgentLocation"
+        if ($AgentLocation -and (Test-Path $AgentLocation)) {
+            $AgentDirectory = (Get-Item $AgentLocation).DirectoryName
+            SetCustomImage $JsonMap.CustomImage $AgentDirectory
+        } else {
+            Write-Error "Could not find agent location; unable to apply CustomImage"
+        }
+    }
 	
 }
 finally {


### PR DESCRIPTION
Ticket: https://evosecurity.atlassian.net/browse/AG-683

## Summary

Fixes a post-install null reference in `InstallEvoAgent.ps1` that could occur after a hybrid agent install.

## Problem

QA reported the installer appeared to complete successfully, but the script ended with:

```text
You cannot call a method on a null-valued expression.
At C:\Users\<user>\Desktop\InstallEvoAgent.ps1:928 char:9
+     return ($Item.ImagePath).Trim('"')
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidOperation: (:) [], RuntimeException
+ FullyQualifiedErrorId : InvokeMethodOnNull
```

Root cause: the script always attempted to resolve the EvoSecureLoginAgent service ImagePath after install, even when no CustomImage was requested.

## Changes

- Added null handling in GetServiceLocation
- Stopped unconditional post-install service lookup
- Kept CustomPrompt application independent of service path resolution
- Limited service path lookup to the CustomImage flow only
- Improved the error message for the specific case where CustomImage cannot be applied

## Verification

- Script parses cleanly after the change
- QA re-ran and confirmed install without errors