### PR TITLE
[AG-751] Add support for configuring protected uninstall

### DIFF
--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -74,6 +74,9 @@
 .PARAMETER PersistentRequest
     Optional setting to enable persistent elevation request notifications instead of having a 10 second timeout
 
+.PARAMETER TamperUninstallPassword
+    Optional password required before uninstalling the Evo Windows Agent
+
 .PARAMETER RMM
     Optional setting to enable RMM (Remote Monitoring and Management) functionality. Only Ninja deployment token retrieval for now. 
 
@@ -149,6 +152,10 @@ param(
     [Parameter(ParameterSetName='DeploymentTokenConfig')]
     [Parameter(ParameterSetName='CommandLineConfig')]
     [Nullable[bool]] $DisableUpdate,
+
+    [Parameter(ParameterSetName='DeploymentTokenConfig')]
+    [Parameter(ParameterSetName='CommandLineConfig')]
+    [string] $TamperUninstallPassword,
 
     [Parameter(ParameterSetName='DeploymentTokenConfig')]
     [Parameter(ParameterSetName='CommandLineConfig')]
@@ -286,6 +293,7 @@ Parameters:
   -DisableEvoUac          Optional setting to disable the Evo credential in the UAC dialog (defaults off or value of previous install, minimum supported agent = 2.4)
   -UnlimitedExtendedUacSession Optional setting to enable unlimited extended UAC session (defaults off or value of previous install, minimum supported agent = 2.4)
   -PersistentRequest      Optional setting to enable persistent elevation request notifications instead of having a 10 second timeout (defaults off or value of previous install, minimum supported agent = 2.4)
+  -TamperUninstallPassword Optional password required before uninstalling the Evo Windows Agent
   -RMM                    Optional setting to enable RMM (Remote Monitoring and Management) functionality -- only Ninja deployment token retrieval for now
   -MSIPath                Optional .msi or .zip file path
   -Upgrade                Validate version is newer before installing
@@ -674,6 +682,10 @@ function ParamMapFromJson {
     }
     elseif ($false -eq $config.DisableUpdate) {
         $ParamMap["DISABLE_UPDATE"] = 0
+    }
+
+    if ($config.TamperUninstallPassword) {
+        $ParamMap["TAMPER_UNINSTALL_PASSWORD"] = $config.TamperUninstallPassword
     }
 
     if ($config.JitMode -eq 1) {
@@ -1145,6 +1157,9 @@ if (-not $Json) {
     }
     if ($null -ne $DisableUpdate) {
         $MapForJson += @{ DisableUpdate = $DisableUpdate}
+    }
+    if ($TamperUninstallPassword) {
+        $MapForJson += @{ TamperUninstallPassword = $TamperUninstallPassword}
     }
     if ($null -ne $JitMode) {
         $MapForJson += @{ JitMode = $JitMode}

--- a/InstallEvoAgent.ps1
+++ b/InstallEvoAgent.ps1
@@ -75,7 +75,8 @@
     Optional setting to enable persistent elevation request notifications instead of having a 10 second timeout
 
 .PARAMETER TamperUninstallPassword
-    Optional password required before uninstalling the Evo Windows Agent
+    Optional uninstall password. When installing, sets the password required before uninstalling.
+    When removing (-Remove), supplies the password so silent uninstall can proceed without a prompt.
 
 .PARAMETER RMM
     Optional setting to enable RMM (Remote Monitoring and Management) functionality. Only Ninja deployment token retrieval for now. 
@@ -160,6 +161,7 @@ param(
 
     [Parameter(ParameterSetName='DeploymentTokenConfig')]
     [Parameter(ParameterSetName='CommandLineConfig')]
+    [Parameter(ParameterSetName='RemoveConfig')]
     [string] $TamperUninstallPassword,
 
     [Parameter(ParameterSetName='DeploymentTokenConfig')]
@@ -272,6 +274,9 @@ Usage Examples:
   Remove:
     .\InstallEvoAgent.ps1 -Remove -Interactive -Log
 
+  Silent remove (when uninstall password protection is enabled):
+    .\InstallEvoAgent.ps1 -Remove -TamperUninstallPassword "your-uninstall-password" -Log
+
   Install from MSI or zip file (legacy):
     .\InstallEvoAgent.ps1 -EnvironmentUrl "..." -EvoDirectory "..." -AccessToken "..." -Secret "..." -MSIPath ".\agent.zip"
 
@@ -305,7 +310,7 @@ Parameters:
   -DisableEvoUac          Optional setting to disable the Evo credential in the UAC dialog (defaults off or value of previous install, minimum supported agent = 2.4)
   -UnlimitedExtendedUacSession Optional setting to enable unlimited extended UAC session (defaults off or value of previous install, minimum supported agent = 2.4)
   -PersistentRequest      Optional setting to enable persistent elevation request notifications instead of having a 10 second timeout (defaults off or value of previous install, minimum supported agent = 2.4)
-  -TamperUninstallPassword Optional password required before uninstalling the Evo Windows Agent
+  -TamperUninstallPassword Optional uninstall password (set on install, or supply with -Remove for silent uninstall)
   -RMM                    Optional setting to enable RMM (Remote Monitoring and Management) functionality -- only Ninja deployment token retrieval for now
   -MSIPath                Optional .msi or .zip file path (legacy; mutually exclusive with InstallerPath)
   -InstallerPath          Optional .msi, .exe, or .zip file path (mutually exclusive with MSIPath)
@@ -1092,7 +1097,8 @@ function DoRemoveAgent()
 {
     param(
         [bool] $Interactive,
-        [bool] $Log
+        [bool] $Log,
+        [string] $TamperUninstallPassword
     )
 
     $DisplayNames = GetInstalledDisplayNames
@@ -1111,19 +1117,31 @@ function DoRemoveAgent()
     }
     Write-Verbose "SoftwareKey: $softwareKey"
 
-    $localParams = @("/X", "`"$($softwareKey.PSChildName)`"")
+    $argString = "/X `"$($softwareKey.PSChildName)`""
     if (-not $Interactive) {
-        $localParams += "/qn"
+        $argString += " /qn"
     }
 
     if ($Log) {
         $LogFileName = Join-Path $Env:TEMP "EvoAgent_remove.log"
-        $localParams += "/log"
-        $localParams += $LogFileName
+        $argString += " /log `"$LogFileName`""
     }
 
-    Write-Verbose "local params: $localParams"
-    Start-InstallerProcess -FilePath "msiexec.exe" -ArgumentList $localParams | Out-Null
+    if ($TamperUninstallPassword) {
+        $msiPropertyArgs = MakeMsiExecArgs @{ TAMPER_UNINSTALL_PASSWORD = $TamperUninstallPassword.Trim() }
+        foreach ($param in $msiPropertyArgs) {
+            if ($null -ne $param -and $param -match '\s') {
+                $escaped = $param -replace '"', '\"'
+                $argString += " `"$escaped`""
+            }
+            elseif ($null -ne $param) {
+                $argString += " $param"
+            }
+        }
+    }
+
+    Write-Verbose "local params: $argString"
+    Start-InstallerProcess -FilePath "msiexec.exe" -ArgumentList $argString | Out-Null
 }
 
 function Get-MSIVersion {
@@ -1307,7 +1325,7 @@ if (-not $Interactive -and -not (IsRunningAsAdministrator)) {
 }
 
 if ($Remove) {
-    return DoRemoveAgent $Interactive $Log
+    return DoRemoveAgent $Interactive $Log $TamperUninstallPassword
 }
 
 $InstalledVersion = GetInstalledVersion

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Minimum supported Agent version for any option is 2.3 unless indicated otherwise
 | `-OnlyEvoLoginCredential` | If set, Evo becomes the only credential provider                                                                                                              | 0                      |
 | `-RememberLastUserName`   | Optional flag to remember the last username used                                                                                                              | 1                      |
 | `-DisableUpdate`          | Optional flag to disable auto updates                                                                                                                         | 0                      |
-| `-TamperUninstallPassword` | Optional password required before uninstalling the Evo Windows Agent                                                                                          |                        |
+| `-TamperUninstallPassword` | Optional uninstall password (set on install, or supply with `-Remove` for silent uninstall)                                                                      |                        |
 | `-JitMode`                | Optional flag to enable Just-In-Time admin accounts                                                                                                           | 0                      |
 | `-EndUserElevation`       | Optional flag to enable end-user elevation                                                                                                                    | 0                      |
 | `-UserAdminEscalation`    | Optional flag to prompt admins with the end-user elevation prompt instead of the standard UAC prompt                                                          | 0                      |
@@ -129,6 +129,12 @@ Use `-InstallerPath` for `.msi`, `.exe`, or `.zip` files. For backwards compatib
 
 ```powershell
 .\InstallEvoAgent.ps1 -Remove -Interactive -Log
+```
+
+### Silent removal (when uninstall password protection is enabled)
+
+```powershell
+.\InstallEvoAgent.ps1 -Remove -TamperUninstallPassword "your-uninstall-password" -Log
 ```
 
 ### Legacy JSON Blob

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ Minimum supported Agent version for any option is 2.3 unless indicated otherwise
 | `-OnlyEvoLoginCredential` | If set, Evo becomes the only credential provider                                                                                                              | 0                      |
 | `-RememberLastUserName`   | Optional flag to remember the last username used                                                                                                              | 1                      |
 | `-DisableUpdate`          | Optional flag to disable auto updates                                                                                                                         | 0                      |
+| `-TamperUninstallPassword` | Optional password required before uninstalling the Evo Windows Agent                                                                                          |                        |
 | `-JitMode`                | Optional flag to enable Just-In-Time admin accounts                                                                                                           | 0                      |
 | `-EndUserElevation`       | Optional flag to enable end-user elevation                                                                                                                    | 0                      |
 | `-UserAdminEscalation`    | Optional flag to prompt admins with the end-user elevation prompt instead of the standard UAC prompt                                                          | 0                      |
@@ -87,6 +88,12 @@ When upgrading, any unspecified parameters are inherited from the previous insta
 
 ```powershell
 .\InstallEvoAgent.ps1 -DeploymentToken "deptoken123abc"
+```
+
+### Install with uninstall password protection
+
+```powershell
+.\InstallEvoAgent.ps1 -DeploymentToken "deptoken123abc" -TamperUninstallPassword "your-uninstall-password"
 ```
 
 ### Install with Ninja deployment token retrieval (agent 2.5+)


### PR DESCRIPTION
## Summary
Adds deployment script support for configuring protected uninstall.

## Changes
- Adds `-TamperUninstallPassword` parameter.
- Passes the password through to the MSI as `TAMPER_UNINSTALL_PASSWORD`.
- Also accepts `-TamperUninstallPassword` with `-Remove` so silent uninstall can proceed without a password prompt.
- Documents the new parameter and example usage.

## Testing
- Installed agent using deployment token only.
- Installed agent with deployment token plus `-TamperUninstallPassword`.
- Verified uninstall password verifier is created and uninstall prompts correctly.